### PR TITLE
docs: Update the .env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ### Configure environment variables
 
-- Copy .env.example to .env
-- Configure your Uniform project
+The project is already configured to use a sample Uniform project.
+Check out the [.env file](./.env) for instructions on how to use your own project instead.
 
 ### Install packages
 


### PR DESCRIPTION
The docs refer to a `.env.example` file which we don't have anymore.

This PR updates the docs to direct the developers to the .env file where they can see info about the environment variables and instructions on how to add their own.